### PR TITLE
fix: Init with the original store

### DIFF
--- a/.changeset/eight-tables-prove.md
+++ b/.changeset/eight-tables-prove.md
@@ -1,0 +1,5 @@
+---
+"redux-persist-transform-expire-in": patch
+---
+
+When the module is added as transform, it returns the current persisted store, if present.

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ const transformExpire = (
   if (storedExpiration) {
     const expiring = parseInt(storedExpiration);
     const now = new Date().getTime();
-    expired = !isNaN(expiring) && now > expiring;
+    expired = Boolean(expiring) && !isNaN(expiring) && now > expiring;
   }
 
   return createTransform(


### PR DESCRIPTION
When the module is added as transform, it returns the current persisted store, if present.